### PR TITLE
fix: change return type of gpd_fan_remove on 6.11

### DIFF
--- a/gpd-fan.c
+++ b/gpd-fan.c
@@ -8,6 +8,7 @@
 #include <linux/kernel.h>
 #include <linux/module.h>
 #include <linux/platform_device.h>
+#include <linux/version.h>
 
 #define DRIVER_NAME "gpdfan"
 
@@ -567,7 +568,11 @@ static int gpd_fan_probe(struct platform_device *pdev) {
     return 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int gpd_fan_remove(__attribute__((unused)) struct platform_device *pdev) {
+#else
+static void gpd_fan_remove(__attribute__((unused)) struct platform_device *pdev) {
+#endif
     struct driver_private_data *data = dev_get_platdata(&pdev->dev);
 
     data->pwm_enable = AUTOMATIC;
@@ -579,7 +584,9 @@ static int gpd_fan_remove(__attribute__((unused)) struct platform_device *pdev) 
     }
 
     pr_info("GPD Devices fan driver removed\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
     return 0;
+#endif
 }
 
 static struct platform_driver gpd_fan_driver = {


### PR DESCRIPTION
Ref:
https://lore.kernel.org/lkml/2024060432-relieving-yonder-85ae@gregkh/T/

Tested on GPD Win Max 2024 (8840U) with linux 6.11

Change-Id: Iddeecdd39314225c466d93f7c81b96662e3ae387